### PR TITLE
Removed excess unused brackets

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -3,13 +3,9 @@
         "lineComment": "//",
     },
     "brackets": [
-        ["[", "]"],
         ["(", ")"]
     ],
-    "autoClosingPairs": [{
-            "open": "[",
-            "close": "]",
-        },
+    "autoClosingPairs": [
         {
             "open": "(",
             "close": ")"
@@ -27,7 +23,6 @@
     ],
     "autoCloseBefore": ";:.,=}]) \n\t",
     "surroundingPairs": [
-        ["[", "]"],
         ["(", ")"],
         ["'", "'"]
     ],


### PR DESCRIPTION
square brackets are not used in scarpet. I would remove the closing comments, but idk if it will crash if i do